### PR TITLE
fix: restart services properly on boot

### DIFF
--- a/templates/upstart.tmpl
+++ b/templates/upstart.tmpl
@@ -3,7 +3,7 @@
 description "{{description}}"
 {% endif %}
 
-start on started network-services
+start on (local-filesystems and net-device-up IFACE!=lo)
 stop on stopping network-services
 respawn
 setuid ubuntu


### PR DESCRIPTION
`start on started network-services` is a stanza that used to work with
older Upstart to start a service once networking comes up.

AFAIK, right now `network-services` is not a service anymore, merely a
red herring in the world of salmons swimming upstream.

cc @bonkydog this fixes the some-services-do-not-come-up-after-reboot problem you've mentioned yesterday :sparkles: 