### PR TITLE
fix: Stop Slack ids casting to numbers

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -33,7 +33,13 @@ module.exports = function(config, app, group)
 			// Parse JSON if possible.
 			try
 			{
-				obj[k] = JSON.parse(obj[k]);
+				var jsonValue = JSON.parse(obj[k]);
+				// Prevent JSON.parse interpreting
+				// periods in numbers as numbers.
+				// For example: Slack client IDs
+				if (typeof jsonValue !== 'number' && jsonValue % 1 !== 0) {
+					obj[k] = jsonValue;
+				}
 			}
 			catch (err) { /* ignored */ }
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -37,7 +37,7 @@ module.exports = function(config, app, group)
 				// Prevent JSON.parse interpreting
 				// periods in numbers as numbers.
 				// For example: Slack client IDs
-				if (typeof jsonValue !== 'number' && jsonValue % 1 !== 0) {
+				if (typeof jsonValue !== 'number' || jsonValue % 1 === 0) {
 					obj[k] = jsonValue;
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "etcetera",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/03-transform.js
+++ b/test/03-transform.js
@@ -37,6 +37,15 @@ describe('transform', function()
 		});
 	});
 
+	it('returns an string for period-separated numbers', function()
+	{
+		transform({
+			foo: '123456123456.123456123456'
+		}, 'app').must.eql({
+			foo: '123456123456.123456123456'
+		});
+	});
+
 	it('preserves all top-level keys', function()
 	{
 		var input = { foo: { one: '1', two: 2, 'one.app': 'one!!!11!!' } };

--- a/test/03-transform.js
+++ b/test/03-transform.js
@@ -46,6 +46,15 @@ describe('transform', function()
 		});
 	});
 
+	it('returns a number for numbers that don\t contain periods', function()
+	{
+		transform({
+			foo: '123456123456123456123456'
+		}, 'app').must.eql({
+			foo: 123456123456123456123456
+		});
+	});
+
 	it('preserves all top-level keys', function()
 	{
 		var input = { foo: { one: '1', two: 2, 'one.app': 'one!!!11!!' } };


### PR DESCRIPTION
- Slack ids are being casted to numbers by JSON.parse. When the output
is of type number and contains a period, bail out